### PR TITLE
fix: ensure releases are build properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG TAG
 RUN cd config/manager \
   && kustomize edit set image controller=${REGISTRY_AND_USERNAME}/${NAME}:${TAG} \
   && cd - \
-  && kustomize config >/control-plane-components.yaml \
+  && kustomize build config >/control-plane-components.yaml \
   && cp config/metadata/metadata.yaml /metadata.yaml
 
 FROM scratch AS release


### PR DESCRIPTION
This fixes a small typo that was causing kustomize generation to fail.