### PR TITLE
fix: ensure machines get proper labels

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -315,6 +315,10 @@ func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, clus
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.SimpleNameGenerator.GenerateName(tcp.Name + "-"),
 			Namespace: tcp.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName:          cluster.ClusterName,
+				capiv1.MachineControlPlaneLabelName: "",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(tcp, controlplanev1.GroupVersion.WithKind("TalosControlPlane")),
 			},


### PR DESCRIPTION
This PR makes sure that the control-plane and cluster labels are applied
to machines that get created. We're supposed to be doing this anyways
and it enables us to filter by label in e2e soon.