### PR TITLE
fix: ensure cleanup happens properly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,28 +1,7 @@
 ---
-kind: secret
-name: kubeconfig
-
-get:
-  path: buildx
-  name: kubeconfig
-
----
 kind: pipeline
 name: default
-
-services:
-  - name: docker
-    image: docker:19.03-dind
-    entrypoint:
-      - dockerd
-    command:
-      - --dns=8.8.8.8
-      - --dns=8.8.4.4
-      - --log-level=error
-    privileged: true
-    volumes:
-      - name: docker-socket
-        path: /var/run
+type: kubernetes
 
 steps:
   - name: setup-ci
@@ -30,20 +9,16 @@ steps:
     commands:
       - git fetch --tags
       - apk add coreutils
-      - echo -e "$BUILDX_KUBECONFIG" > /root/.kube/config
-      - docker buildx create --driver kubernetes --driver-opt replicas=2 --driver-opt namespace=ci --driver-opt image=moby/buildkit:v0.6.2 --name ci --buildkitd-flags="--allow-insecure-entitlement security.insecure" --use
+      - docker buildx create --driver docker-container --platform linux/amd64 --buildkitd-flags "--allow-insecure-entitlement security.insecure" --name local --use unix:///var/outer-run/docker.sock
       - docker buildx inspect --bootstrap
-    environment:
-      BUILDX_KUBECONFIG:
-        from_secret: kubeconfig
     privileged: true
     volumes:
       - name: docker-socket
         path: /var/run
+      - name: outerdockersock
+        path: /var/outer-run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
   - name: build-pull-request
     image: autonomy/build-container:latest
@@ -57,10 +32,10 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
+      - name: outerdockersock
+        path: /var/outer-run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
   - name: build-and-publish
     image: autonomy/build-container:latest
@@ -80,10 +55,11 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
+      - name: outerdockersock
+        path: /var/outer-run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
+
 
   - name: build-release
     image: autonomy/build-container:latest
@@ -96,10 +72,10 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
+      - name: outerdockersock
+        path: /var/outer-run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
   - name: release
     image: plugins/github-release
@@ -119,13 +95,15 @@ steps:
 volumes:
   - name: docker-socket
     temp: {}
+  - name: outerdockersock
+    host:
+      path: /var/ci-docker
   - name: docker
-    temp: {}
-  - name: kube
     temp: {}
 ---
 kind: pipeline
 name: notify
+type: kubernetes
 
 clone:
   disable: true


### PR DESCRIPTION
This PR updates the deletion portion of the control plane provider to
also trigger deletion of any control plane machines in the cluster. This
mimics the behavior done in the kubeadm control plane provider.
Additionally, there were some updates to the way we add ownerrefs to
make sure that the refs are created with blockOwnerDeletion set to true
to make sure the full cluster can't get torn down without tearing down
these decendents.