### PR TITLE
chore: update image pull policy

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
         args:
         - --enable-leader-election
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         resources:
           limits:


### PR DESCRIPTION
We should always be pulling the control plane provider image.

Will close #21 