### PR TITLE
fix: update resources for deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,9 +25,9 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 500Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 500m
+            memory: 500Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This PR updates the resource limits for this provider. Users saw issues
where the previously set values were too small when being used at scale
and causing OOM killing.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>