### PR TITLE
fix: back down resource requests

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,18 +16,18 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - command:
-        - /manager
-        args:
-        - --enable-leader-election
-        image: controller:latest
-        imagePullPolicy: Always
-        name: manager
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 500Mi
-          requests:
-            cpu: 500m
-            memory: 500Mi
+        - command:
+            - /manager
+          args:
+            - --enable-leader-election
+          image: controller:latest
+          imagePullPolicy: Always
+          name: manager
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This fixes an issue where we can't install on a 2 CPU/2GB RAM
node. Backing down the requests so that the pods can get scheduled, but
still keeping the limits high.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
