### PR TITLE
fix: protect metrics-addr by default

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,7 @@ spec:
         - command:
             - /manager
           args:
+            - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
           image: controller:latest
           imagePullPolicy: Always


### PR DESCRIPTION
As we don't deploy kube-rbac-proxy, protect metrics-addr by binding to
the localhost.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>