### PR TITLE
test: implement scale up and down tests and fix found issues

### DIFF
--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -12,8 +12,91 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	talosclient "github.com/talos-systems/talos/pkg/machinery/client"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, cluster *capiv1.Cluster, ownedMachines []capiv1.Machine) error {
+	clientset, err := r.kubeconfigForCluster(ctx, util.ObjectKey(cluster))
+	if err != nil {
+		return err
+	}
+
+	machines := []capiv1.Machine{}
+
+	for _, machine := range ownedMachines {
+		if machine.ObjectMeta.DeletionTimestamp.IsZero() {
+			machines = append(machines, machine)
+		}
+	}
+
+	c, err := r.talosconfigForMachines(ctx, clientset, machines...)
+	if err != nil {
+		return err
+	}
+
+	service := "etcd"
+
+	params := make([]interface{}, 0, len(machines)*2)
+	for _, machine := range machines {
+		params = append(params, "node", machine.Name)
+	}
+
+	r.Log.Info("Verifying etcd health on all nodes", params...)
+
+	svcs, err := c.ServiceInfo(ctx, service)
+	if err != nil {
+		return err
+	}
+
+	// check that etcd service is healthy on all nodes
+	for _, svc := range svcs {
+		node := svc.Metadata.GetHostname()
+
+		if len(svc.Service.Events.Events) == 0 {
+			return fmt.Errorf("%s: no events recorded yet for service %q", node, service)
+		}
+
+		lastEvent := svc.Service.Events.Events[len(svc.Service.Events.Events)-1]
+		if lastEvent.State != "Running" {
+			return fmt.Errorf("%s: service %q not in expected state %q: current state [%s] %s", node, service, "Running", lastEvent.State, lastEvent.Msg)
+		}
+
+		if !svc.Service.GetHealth().GetHealthy() {
+			return fmt.Errorf("%s: service is not healthy: %s", node, service)
+		}
+	}
+
+	resp, err := c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{})
+	if err != nil {
+		return err
+	}
+
+	members := map[string]struct{}{}
+
+	for i, message := range resp.Messages {
+		actualMembers := len(message.Members)
+		expectedMembers := len(machines)
+
+		node := message.Metadata.GetHostname()
+
+		// check that the count of members is the same on all nodes
+		if actualMembers != expectedMembers {
+			return fmt.Errorf("%s: expected to have %d members, got %d", node, expectedMembers, actualMembers)
+		}
+
+		// check that member list is the same on all nodes
+		for _, member := range message.Members {
+			if _, found := members[member.Hostname]; i > 0 && !found {
+				return fmt.Errorf("%s: found extra etcd member %s", node, member.Hostname)
+			}
+
+			members[member.Hostname] = struct{}{}
+		}
+	}
+
+	return nil
+}
 
 // gracefulEtcdLeave removes a given machine from the etcd cluster by forfeiting leadership
 // and issuing a "leave" request from the machine itself.
@@ -100,7 +183,7 @@ func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, cluster cli
 		return err
 	}
 
-	c, err := r.talosconfigForMachine(ctx, clientset, designatedCPMachine)
+	c, err := r.talosconfigForMachines(ctx, clientset, designatedCPMachine)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,17 @@ replace (
 )
 
 require (
+	github.com/coreos/go-semver v0.3.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/capi-utils v0.0.0-20210906195159-c20b1a80b427
+	github.com/talos-systems/capi-utils v0.0.0-20210910152701-028c7d3c0257
 	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0
 	github.com/talos-systems/talos/pkg/machinery v0.12.0
+	google.golang.org/grpc v1.40.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -596,8 +597,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/talos-systems/capi-utils v0.0.0-20210906195159-c20b1a80b427 h1:oVMP3FQN/tiKyWm7uqVeX8BoPUXekUeslSBzFSiyXc0=
-github.com/talos-systems/capi-utils v0.0.0-20210906195159-c20b1a80b427/go.mod h1:2tv16Wyfosr2iwk5jL+uQg6KQmtpHpByvShmet4TIs8=
+github.com/talos-systems/capi-utils v0.0.0-20210910152701-028c7d3c0257 h1:cg+bUXpiGxBq+zaysXeg0j2DD5dYnkSs4DbwFNa4fiQ=
+github.com/talos-systems/capi-utils v0.0.0-20210910152701-028c7d3c0257/go.mod h1:2tv16Wyfosr2iwk5jL+uQg6KQmtpHpByvShmet4TIs8=
 github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0 h1:neYRQZWXYI2b0s9XVUfL4teOZQ1d+CTgvBLgKo5QhzE=
 github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0/go.mod h1:lzie3WxFNZZVMGsCDInNvE8N1ZJuE5X8D+pKTxZ+uKc=
 github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -22,7 +22,7 @@ TAG="${TAG:-$(git describe --tag --always --dirty)}"
 REGION="us-east-1"
 BUCKET="talos-ci-e2e"
 PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
-TALOS_VERSION="${TALOS_DEFAULT:-v0.12.0}"
+TALOS_VERSION="${TALOS_DEFAULT:-v0.12.1}"
 K8S_VERSION="${K8S_VERSION:-v1.21.3}"
 KUBECONFIG=
 AMI=${AWS_AMI:-$(curl -sL https://github.com/talos-systems/talos/releases/download/${TALOS_VERSION}/cloud-images.json | \
@@ -41,6 +41,7 @@ cleanup() {
       curl -Lo kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${PLATFORM}/amd64/kubectl"
       chmod +x kubectl
 
+      ./kubectl delete cluster --all || true
       ./kubectl logs -n capa-system deployment/capa-controller-manager manager || true
       ./kubectl logs -n cacppt-system deployment/cacppt-controller-manager || true
     fi
@@ -133,6 +134,7 @@ aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}" | base64 -w0)
 }
 
 function tests {
+  export WORKLOAD_TALOS_VERSION=${TALOS_VERSION}
   ./_out/integration.test -test.v
 }
 


### PR DESCRIPTION
Fixes:
 - Check etcd health on all nodes before scaling down.
 - Check all nodes are booted before scaling down.
 - Do not call `Shutdown` during machine deletion (only for Talos >= 0.12.2).
    
Scale down tests are disabled for Talos < 0.12.2.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>