### PR TITLE
fix: update metadata.yaml for v0.2 of CACPPT

### DIFF
--- a/config/metadata/metadata.yaml
+++ b/config/metadata/metadata.yaml
@@ -4,4 +4,6 @@ releaseSeries:
 - major: 0
   minor: 1
   contract: v1alpha3
-
+- major: 0
+  minor: 2
+  contract: v1alpha3

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -197,7 +197,7 @@ func (suite *IntegrationSuite) Test02ReconcileMachine() {
 	suite.Require().NoError(
 		retry.Constant(15*time.Minute, retry.WithUnits(4*time.Second), retry.WithErrorLogging(true)).Retry(func() error {
 			if e := suite.cluster.Sync(suite.ctx); e != nil {
-				return e
+				return retry.ExpectedError(e)
 			}
 
 			etcdMembers, e := getEtcdMembers()


### PR DESCRIPTION
This PR makes sure we'll generate a working metadata for clusterctl to
use for the v0.2 release series.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>