### PR TITLE
feat: get rid of init nodes and use bootstrap API to setup cluster

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,6 +81,8 @@ steps:
         from_secret: aws_secret_access_key
       CI: true
       REGISTRY: registry.dev.talos-systems.io
+      GITHUB_TOKEN:
+        from_secret: github_token
     commands:
       - make integration-test
     volumes:

--- a/api/v1alpha3/conditions.go
+++ b/api/v1alpha3/conditions.go
@@ -16,6 +16,15 @@ const (
 )
 
 const (
+	// MachinesBootstrapped is tracking control planes bootstrap status.
+	MachinesBootstrapped clusterv1.ConditionType = "MachinesBootstrapped"
+
+	// WaitingForMachinesReason (Severity=Info) documents a TalosControlPlane bootstrap is waiting
+	// for all control plane nodes to be created.
+	WaitingForMachinesReason = "WaitingForMachines"
+)
+
+const (
 	// AvailableCondition documents that the first control plane instance has completed Talos boot sequence
 	// and so the control plane is available and an API server instance is ready for processing requests.
 	AvailableCondition clusterv1.ConditionType = "Available"
@@ -23,6 +32,10 @@ const (
 	// WaitingForTalosBootReason (Severity=Info) documents a TalosControlPlane object waiting for the first
 	// control plane instance to complete Talos boot sequence.
 	WaitingForTalosBootReason = "WaitingForTalosBoot"
+
+	// InvalidControlPlaneConfigReason (Severity=Error) documents that controlplane config is invalid and the provider
+	// can not proceed with the bootstrap.
+	InvalidControlPlaneConfigReason = "InvalidControlPlaneConfig"
 )
 
 const (

--- a/api/v1alpha3/taloscontrolplane_types.go
+++ b/api/v1alpha3/taloscontrolplane_types.go
@@ -16,7 +16,8 @@ const (
 )
 
 type ControlPlaneConfig struct {
-	InitConfig         cabptv1.TalosConfigSpec `json:"init"`
+	// Deprecated: starting from cacppt v0.4.0 provider doesn't use init configs.
+	InitConfig         cabptv1.TalosConfigSpec `json:"init,omitempty"`
 	ControlPlaneConfig cabptv1.TalosConfigSpec `json:"controlplane"`
 }
 
@@ -78,6 +79,11 @@ type TalosControlPlaneStatus struct {
 	// receive requests.
 	// +optional
 	Ready bool `json:"ready"`
+
+	// Bootstrapped denotes whether any nodes received bootstrap request
+	// which is required to start etcd and Kubernetes components in Talos.
+	// +optional
+	Bootstrapped bool `json:"bootstrapped,omitempty"`
 
 	// FailureReason indicates that there is a terminal problem reconciling the
 	// state, and will be set to a token value suitable for

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_taloscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_taloscontrolplanes.yaml
@@ -87,7 +87,7 @@ spec:
                     - generateType
                     type: object
                   init:
-                    description: TalosConfigSpec defines the desired state of TalosConfig
+                    description: 'Deprecated: starting from cacppt v0.4.0 provider doesn''t use init configs.'
                     properties:
                       configPatches:
                         items:
@@ -114,7 +114,6 @@ spec:
                     type: object
                 required:
                 - controlplane
-                - init
                 type: object
               infrastructureTemplate:
                 description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
@@ -158,6 +157,9 @@ spec:
           status:
             description: TalosControlPlaneStatus defines the observed state of TalosControlPlane
             properties:
+              bootstrapped:
+                description: Bootstrapped denotes wheither any nodes recieved bootstrap request which is required to start etcd and Kubernetes components in Talos.
+                type: boolean
               conditions:
                 description: Conditions defines current service state of the KubeadmControlPlane.
                 items:

--- a/controllers/consts.go
+++ b/controllers/consts.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import "time"
+
+const (
+	// deleteRequeueAfter is how long to wait before checking again to see if
+	// all control plane machines have been deleted.
+	deleteRequeueAfter = 30 * time.Second
+
+	// preflightFailedRequeueAfter is how long to wait before trying to scale
+	// up/down if some preflight check for those operation has failed.
+	preflightFailedRequeueAfter = 15 * time.Second
+
+	// dependentCertRequeueAfter is how long to wait before checking again to see if
+	// dependent certificates have been created.
+	dependentCertRequeueAfter = 30 * time.Second
+)

--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -32,7 +32,7 @@ func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, clust
 		}
 	}
 
-	c, err := r.talosconfigForMachines(ctx, kubeclient.Clientset, machines...)
+	c, err := r.talosconfigForMachines(ctx, machines...)
 	if err != nil {
 		return err
 	}
@@ -182,14 +182,7 @@ func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, cluster cli
 		return fmt.Errorf("no CP machine which is not being deleted and has node ref")
 	}
 
-	kubeclient, err := r.kubeconfigForCluster(ctx, cluster)
-	if err != nil {
-		return err
-	}
-
-	defer kubeclient.Close() //nolint:errcheck
-
-	c, err := r.talosconfigForMachines(ctx, kubeclient.Clientset, designatedCPMachine)
+	c, err := r.talosconfigForMachines(ctx, designatedCPMachine)
 	if err != nil {
 		return err
 	}

--- a/controllers/health.go
+++ b/controllers/health.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
 )
 
 type errServiceUnhealthy struct {
@@ -29,14 +28,7 @@ func (e *errServiceUnhealthy) Error() string {
 }
 
 func (r *TalosControlPlaneReconciler) nodesHealthcheck(ctx context.Context, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
-	kubeclient, err := r.kubeconfigForCluster(ctx, util.ObjectKey(cluster))
-	if err != nil {
-		return err
-	}
-
-	defer kubeclient.Close() //nolint:errcheck
-
-	client, err := r.talosconfigForMachines(ctx, kubeclient.Clientset, machines...)
+	client, err := r.talosconfigForMachines(ctx, machines...)
 	if err != nil {
 		return err
 	}
@@ -63,14 +55,7 @@ func (r *TalosControlPlaneReconciler) nodesHealthcheck(ctx context.Context, clus
 }
 
 func (r *TalosControlPlaneReconciler) ensureNodesBooted(ctx context.Context, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
-	kubeclient, err := r.kubeconfigForCluster(ctx, util.ObjectKey(cluster))
-	if err != nil {
-		return err
-	}
-
-	defer kubeclient.Close() //nolint:errcheck
-
-	client, err := r.talosconfigForMachines(ctx, kubeclient.Clientset, machines...)
+	client, err := r.talosconfigForMachines(ctx, machines...)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/onsi/gomega v1.16.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/capi-utils v0.0.0-20211101220445-144451cdef39
-	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0-alpha.0
+	github.com/talos-systems/capi-utils v0.0.0-20211126110629-e8c3bf93e75f
+	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0
 	github.com/talos-systems/go-retry v0.3.1
 	github.com/talos-systems/talos/pkg/machinery v0.13.0
 	google.golang.org/grpc v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -598,10 +598,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/talos-systems/capi-utils v0.0.0-20211101220445-144451cdef39 h1:6uBT5MqsSFCLz9PGFcwe4k/1agpO8NNUVWRRMoWiZK0=
-github.com/talos-systems/capi-utils v0.0.0-20211101220445-144451cdef39/go.mod h1:aVPVu5QD40PTYpSE2V6IbKf79AZyh4SQqP7Q+uO/lf8=
-github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0-alpha.0 h1:U/GWSEWCZkCcqPiFxOCrj+ajlUrOtedNKyv24oAreNs=
-github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0-alpha.0/go.mod h1:WXR/HRu/tOUv59ybYNclTJj1moaJvnSzJ1vnjXZLX48=
+github.com/talos-systems/capi-utils v0.0.0-20211126110629-e8c3bf93e75f h1:nqD7FdQEqkXh7TXodfxXgBZdV9SHpP1GWA9jGsZL7os=
+github.com/talos-systems/capi-utils v0.0.0-20211126110629-e8c3bf93e75f/go.mod h1:aVPVu5QD40PTYpSE2V6IbKf79AZyh4SQqP7Q+uO/lf8=
+github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0 h1:bikfr+P3LzuWSxW4fWL/hiDtoHTqH/MOnleGP/EZ60U=
+github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.0/go.mod h1:WXR/HRu/tOUv59ybYNclTJj1moaJvnSzJ1vnjXZLX48=
 github.com/talos-systems/crypto v0.3.2/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/crypto v0.3.4 h1:bg4N27CH1MvUBasr70BlZObPXQYEhUTwOOm/jhCRFxg=
 github.com/talos-systems/crypto v0.3.4/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -23,7 +23,7 @@ REGION="us-east-1"
 BUCKET="talos-ci-e2e"
 PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
 TALOS_VERSION="${TALOS_DEFAULT:-v0.13.1}"
-K8S_VERSION="${K8S_VERSION:-v1.22.2}"
+K8S_VERSION="${K8S_VERSION:-v1.22.3}"
 KUBECONFIG=
 AMI=${AWS_AMI:-$(curl -sL https://github.com/talos-systems/talos/releases/download/${TALOS_VERSION}/cloud-images.json | \
     jq -r --arg REGION "${REGION}" '.[] | select(.region == $REGION) | select (.arch == "amd64") | .id')}


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/cluster-api-control-plane-provider-talos/issues/74

That required couple changes in the manager flow:
- no longer get node IPs using `kubectl get nodes`, but use machines
addresses instead.
- add `MachinesBootstrapped` condition that means that `bootstrap` was
called on one of the machines.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>