### PR TITLE
fix: properly pick talos client configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,16 @@ TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 NAME := cluster-api-control-plane-talos-controller
+WITH_RACE ?= false
+CGO_ENABLED = 0
+
+ifneq (, $(filter $(WITH_RACE), t true TRUE y yes 1))
+GO_BUILDFLAGS += -race
+CGO_ENABLED = 1
+GO_LDFLAGS += -linkmode=external -extldflags '-static'
+endif
+
+GO_LDFLAGS += -s -w
 
 ARTIFACTS := _out
 
@@ -23,6 +33,9 @@ COMMON_ARGS += --build-arg=NAME=$(NAME)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=PKGS=$(PKGS)
 COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
+COMMON_ARGS += --build-arg=GO_BUILDFLAGS="$(GO_BUILDFLAGS)"
+COMMON_ARGS += --build-arg=GO_LDFLAGS="$(GO_LDFLAGS)"
+COMMON_ARGS += --build-arg=CGO_ENABLED="$(CGO_ENABLED)"
 
 all: manifests container
 

--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -118,11 +118,12 @@ func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context
 				return nil, err
 			}
 
+		outer:
 			for _, cfg := range cfgs.Items {
 				for _, ref := range cfg.OwnerReferences {
 					if ref.Kind == "Machine" && ref.Name == machine.Name {
 						found = &cfg
-						break
+						break outer
 					}
 				}
 			}


### PR DESCRIPTION
There was a bug in talosconfig iteration nested loop that `break` was
just stopping the internal loop.

Also allow building the container with race enabled.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>