### PR TITLE
fix: do not allow scaling down controlplane to zero

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -273,6 +273,14 @@ func (r *TalosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			"Scaling down control plane to %d replicas (actual %d)",
 			desiredReplicas, numMachines)
 
+		if numMachines == 1 {
+			conditions.MarkFalse(tcp, controlplanev1.ResizedCondition, controlplanev1.ScalingDownReason, clusterv1.ConditionSeverityError,
+				"Cannot scale down control plane nodes to 0",
+				desiredReplicas, numMachines)
+
+			return res, nil
+		}
+
 		if err := r.ensureNodesBooted(ctx, cluster, ownedMachines); err != nil {
 			logger.Info("Waiting for all nodes to finish boot sequence", "error", err)
 


### PR DESCRIPTION
Doing that is pretty pointless as it's going to destroy a cluster.
Instead of doing that cluster should be deleted and recreated.

And with the new approach without init nodes scaling cluster back up
won't be able to succeed as bootstrap is done only a single time.

Still allowing user to set replicas to zero, but block scaling in the
controller with error messages when there's only a single node
remaining.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>