### PR TITLE
backports: for v0.4.0-beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ This provider's versions are compatible with the following versions of Talos:
 This control plane provider can be installed with clusterctl:
 
 ```bash
-clusterctl init -c talos -b talos
+clusterctl init -c talos -b talos -i <infra-provider-of-choice>
 ```
+
+If you are going to use this provider as part of Sidero management plane, please refer to [Sidero Docs](https://www.sidero.dev/docs/v0.4/getting-started/install-clusterapi/)
+on how to install and configure it.
 
 This project can be built simply by running `make release` from the root directory.
 Doing so will create a file called `_out/control-plane-components.yaml`.
@@ -58,8 +61,76 @@ You will need at least the upstream CAPI components, the Talos bootstrap provide
 
 ## Usage
 
+### Supported Templates
+
 You can use recommended [Cluster API templates](https://github.com/talos-systems/cluster-api-templates) provided by Sidero Labs.
+
 It contains templates for `AWS` and `GCP`, which are verified by the integration tests.
 
-If you are going to use this provider as part of Sidero management plane, please refer to [Sidero Docs](https://www.sidero.dev/docs/v0.4/getting-started/install-clusterapi/)
-on how to install and configure it.
+### Creating Your Own Templates
+
+If you wish to craft your own manifests, here is some important info.
+
+CACPPT supports a single API type, a TalosControlPlane.
+You can create YAML definitions of a TalosControlPlane and `kubectl apply` them as part of a larger CAPI cluster deployment.
+Below is a bare-minimum example.
+
+A basic config:
+
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
+metadata:
+  name: talos-cp
+spec:
+  version: v1.18.1
+  replicas: 1
+  infrastructureTemplate:
+    kind: MetalMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    name: talos-cp
+  controlPlaneConfig:
+    controlplane:
+      generateType: controlplane
+```
+
+Note you must provide an infrastructure template for your control plane.
+See your infrastructure provider for how to craft that.
+
+Note the generateType mentioned above.
+This is a required value in the spec for both controlplane and worker ("join") nodes.
+For a no-frills control plane config, you can simply specify `controlplane` depending on each config section.
+When creating a TalosControlPlane this way, you can then retrieve the talosconfig file that allows for osctl interaction with your nodes by doing something like `kubectl get talosconfig -o yaml talos-cp-xxxx -o jsonpath='{.status.talosConfig}'` after creation.
+
+If you wish to do something more complex, we allow for the ability to supply an entire Talos machine config file to the resource.
+This can be done by setting the generateType to `none` and specifying a `data` field.
+This config file can be generated with `talosctl config generate` and the edited to supply the various options you may desire.
+This full config is blindly copied from the `data` section of the spec and presented under `.status.controlPlaneData` so that the upstream CAPI controllers can see it and make use.
+
+An example of a more complex config:
+
+```yaml
+apiVersion: control-plane.cluster.x-k8s.io/v1alpha2
+kind: TalosControlPlane
+metadata:
+  name: talos-0
+  labels:
+    cluster.x-k8s.io/cluster-name: talos
+spec:
+  controlPlaneConfig:
+    init:
+        generateType: none
+        data: |
+            version: v1alpha1
+            machine:
+            type: controlplane
+            token: xxxxxx
+            ...
+            ...
+            ...
+  ...
+  ...
+```
+
+Note that specifying the full config above removes the ability for our control plane provider to generate a talosconfig for use.
+As such, you should keep track of the talosconfig that's generated when running `talosctl config generate`.

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-TMP="/tmp/cacppt-e2e/"
+TMP="/tmp/cacppt-e2e"
 mkdir -p "${TMP}"
 
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
@@ -27,7 +27,7 @@ K8S_VERSION="${K8S_VERSION:-v1.22.3}"
 KUBECONFIG=
 AMI=${AWS_AMI:-$(curl -sL https://github.com/talos-systems/talos/releases/download/${TALOS_VERSION}/cloud-images.json | \
     jq -r --arg REGION "${REGION}" '.[] | select(.region == $REGION) | select (.arch == "amd64") | .id')}
-export PROVIDER=aws:v1.0.0
+export PROVIDER=aws:v1.1.0
 
 CREATED_CLUSTER=""
 TALOSCTL_PATH="${TMP}/talosctl"
@@ -135,6 +135,7 @@ function aws_setup {
   export AWS_SSH_KEY_NAME=${AWS_SSH_KEY_NAME:-talos-e2e}
   export AWS_VPC_ID=${AWS_VPC_ID:-vpc-ff5c5687}
   export AWS_SUBNET=${AWS_SUBNET:-subnet-c4e9b3a0}
+  export AWS_SUBNET_AZ=${AWS_SUBNET_AZ:-us-east-1a}
 
   ## Control plane vars
   export AWS_CONTROL_PLANE_AMI_ID=${AMI}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -71,7 +71,7 @@ func (suite *IntegrationSuite) SetupSuite() {
 		return def
 	}
 
-	providerType := env("PROVIDER", "aws:v1.0.0")
+	providerType := env("PROVIDER", "aws:v1.1.0")
 
 	provider, err := infrastructure.NewProvider(providerType)
 	suite.Require().NoError(err)
@@ -124,8 +124,8 @@ func (suite *IntegrationSuite) SetupSuite() {
 	}
 
 	options := capi.Options{
-		CoreProvider:            env("CORE_PROVIDER", "cluster-api:v1.0.0"),
-		BootstrapProviders:      []string{"talos:v0.5.0-alpha.0"},
+		CoreProvider:            env("CORE_PROVIDER", "cluster-api:v1.0.2"),
+		BootstrapProviders:      []string{"talos:v0.5.0"},
 		InfrastructureProviders: []infrastructure.Provider{provider},
 		ControlPlaneProviders:   []string{"talos"},
 		WaitProviderTimeout:     time.Minute,
@@ -150,7 +150,7 @@ func (suite *IntegrationSuite) SetupSuite() {
 	cluster, err := manager.DeployCluster(suite.ctx, fmt.Sprintf("caccpt-test-cluster-%s", id.String()[:7]),
 		capi.WithProvider(provider.Name()),
 		capi.WithKubernetesVersion(strings.TrimLeft(env("WORKLOAD_KUBERNETES_VERSION", env("K8S_VERSION", "v1.22.2")), "v")),
-		capi.WithTemplateFile("https://github.com/Unix4ever/cluster-api-templates/blob/drop-init-configs/aws/standard/standard.yaml"),
+		capi.WithTemplateFile("https://github.com/talos-systems/cluster-api-templates/blob/v1beta1/aws/standard/standard.yaml"),
 	)
 	suite.Require().NoError(err)
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -151,6 +151,7 @@ func (suite *IntegrationSuite) SetupSuite() {
 		capi.WithProvider(provider.Name()),
 		capi.WithKubernetesVersion(strings.TrimLeft(env("WORKLOAD_KUBERNETES_VERSION", env("K8S_VERSION", "v1.22.2")), "v")),
 		capi.WithTemplateFile("https://github.com/talos-systems/cluster-api-templates/blob/v1beta1/aws/standard/standard.yaml"),
+		capi.WithControlPlaneNodes(3),
 	)
 	suite.Require().NoError(err)
 
@@ -168,17 +169,8 @@ func (suite *IntegrationSuite) TearDownSuite() {
 	}
 }
 
-// Test01ScaleUp scale control plane nodes up.
-func (suite *IntegrationSuite) Test01ScaleUp() {
-	suite.cluster.Scale(suite.ctx, 3, capi.ControlPlaneNodes) //nolint:errcheck
-
-	suite.Require().NoError(suite.cluster.Health(suite.ctx))
-
-	time.Sleep(2 * time.Second)
-}
-
-// Test02ReconcileMachine remove a machine and wait until cluster gets healthy again.
-func (suite *IntegrationSuite) Test02ReconcileMachine() {
+// Test01ReconcileMachine remove a machine and wait until cluster gets healthy again.
+func (suite *IntegrationSuite) Test01ReconcileMachine() {
 	selector, err := labels.Parse("cluster.x-k8s.io/control-plane")
 	suite.Require().NoError(err)
 
@@ -262,7 +254,7 @@ func (suite *IntegrationSuite) Test02ReconcileMachine() {
 	)
 }
 
-// Test03ScaleDown scale control planes down.
+// Test02ScaleDown scale control planes down.
 func (suite *IntegrationSuite) Test03ScaleDown() {
 	suite.Require().NoError(suite.cluster.Sync(suite.ctx))
 
@@ -274,7 +266,7 @@ func (suite *IntegrationSuite) Test03ScaleDown() {
 	suite.Require().NoError(suite.cluster.Sync(suite.ctx))
 }
 
-// Test04ScaleControlPlaneNoWait scale control plane nodes up and down without waiting.
+// Test03ScaleControlPlaneNoWait scale control plane nodes up and down without waiting.
 func (suite *IntegrationSuite) Test04ScaleControlPlaneNoWait() {
 	ctx, cancel := context.WithCancel(suite.ctx)
 
@@ -290,7 +282,7 @@ func (suite *IntegrationSuite) Test04ScaleControlPlaneNoWait() {
 	suite.Require().NoError(err)
 }
 
-// Test05ScaleControlPlaneToZero try to scale control plane to zero and check that it never does that.
+// Test04ScaleControlPlaneToZero try to scale control plane to zero and check that it never does that.
 func (suite *IntegrationSuite) Test05ScaleControlPlaneToZero() {
 	ctx, cancel := context.WithCancel(suite.ctx)
 


### PR DESCRIPTION
This PR bundles the backports for release-0.4 branch needed for v0.4.0-beta.1

See:

65043b7cf85407e9e4683dbda1d96083d9e1de45
e0041f6567a61a388f5e69769fe28924e4f4fe7f
