### PR TITLE
fix: refactor reconcile loop

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_taloscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_taloscontrolplanes.yaml
@@ -158,7 +158,7 @@ spec:
             description: TalosControlPlaneStatus defines the observed state of TalosControlPlane
             properties:
               bootstrapped:
-                description: Bootstrapped denotes wheither any nodes recieved bootstrap request which is required to start etcd and Kubernetes components in Talos.
+                description: Bootstrapped denotes whether any nodes received bootstrap request which is required to start etcd and Kubernetes components in Talos.
                 type: boolean
               conditions:
                 description: Conditions defines current service state of the KubeadmControlPlane.


### PR DESCRIPTION
Refactor reconcile loop to resemble Kubeadm controlplane controller.
Now it tries to reconcile: `etcd status`, `nodes health`, `bootstrap
status` and `kubeconfig` on each reconcile call.
This makes kubeconfig available much earlier and also different
reconcile phases do not cancel each other anymore.
    
Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
