### PR TITLE
fix: fall back to old scheme of getting talsoconfig for older templates

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -8,12 +8,15 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	cabptv1 "github.com/talos-systems/cluster-api-bootstrap-provider-talos/api/v1alpha3"
+	controlplanev1 "github.com/talos-systems/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	talosclient "github.com/talos-systems/talos/pkg/machinery/client"
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -75,9 +78,13 @@ func (r *TalosControlPlaneReconciler) kubeconfigForCluster(ctx context.Context, 
 }
 
 // talosconfigForMachine will generate a talosconfig that uses *all* found addresses as the endpoints.
-func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context, machines ...clusterv1.Machine) (*talosclient.Client, error) {
+func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context, tcp *controlplanev1.TalosControlPlane, machines ...clusterv1.Machine) (*talosclient.Client, error) {
 	if len(machines) == 0 {
 		return nil, fmt.Errorf("at least one machine should be provided")
+	}
+
+	if !reflect.ValueOf(tcp.Spec.ControlPlaneConfig.InitConfig).IsZero() {
+		return r.talosconfigFromWorkloadCluster(ctx, client.ObjectKey{Namespace: tcp.GetNamespace(), Name: tcp.GetLabels()["cluster.x-k8s.io/cluster-name"]}, machines...)
 	}
 
 	addrList := []string{}
@@ -113,6 +120,77 @@ func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context
 					if ref.Kind == "Machine" && ref.Name == machine.Name {
 						found = &cfg
 						break outer
+					}
+				}
+			}
+
+			if found == nil {
+				return nil, fmt.Errorf("failed to find TalosConfig for %q", machine.Name)
+			}
+
+			t, err = talosconfig.FromString(found.Status.TalosConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return talosclient.New(ctx, talosclient.WithEndpoints(addrList...), talosclient.WithConfig(t))
+}
+
+// talosconfigFromWorkloadCluster gets talosconfig and populates endoints using workload cluster nodes.
+func (r *TalosControlPlaneReconciler) talosconfigFromWorkloadCluster(ctx context.Context, cluster client.ObjectKey, machines ...clusterv1.Machine) (*talosclient.Client, error) {
+	if len(machines) == 0 {
+		return nil, fmt.Errorf("at least one machine should be provided")
+	}
+
+	clientset, err := r.kubeconfigForCluster(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	addrList := []string{}
+
+	var t *talosconfig.Config
+
+	for _, machine := range machines {
+		if machine.Status.NodeRef == nil {
+			return nil, fmt.Errorf("%q machine does not have a nodeRef", machine.Name)
+		}
+
+		// grab all addresses as endpoints
+		node, err := clientset.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeExternalIP || addr.Type == corev1.NodeInternalIP {
+				addrList = append(addrList, addr.Address)
+			}
+		}
+
+		if len(addrList) == 0 {
+			return nil, fmt.Errorf("no addresses were found for node %q", node.Name)
+		}
+
+		if t == nil {
+			var (
+				cfgs  cabptv1.TalosConfigList
+				found *cabptv1.TalosConfig
+			)
+
+			// find talosconfig in the machine's namespace
+			err = r.Client.List(ctx, &cfgs, client.InNamespace(machine.Namespace))
+			if err != nil {
+				return nil, err
+			}
+
+			for _, cfg := range cfgs.Items {
+				for _, ref := range cfg.OwnerReferences {
+					if ref.Kind == "Machine" && ref.Name == machine.Name {
+						found = &cfg
+						break
 					}
 				}
 			}

--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	controlplanev1 "github.com/talos-systems/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	talosclient "github.com/talos-systems/talos/pkg/machinery/client"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -16,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, cluster *clusterv1.Cluster, ownedMachines []clusterv1.Machine) error {
+func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, tcp *controlplanev1.TalosControlPlane, cluster *clusterv1.Cluster, ownedMachines []clusterv1.Machine) error {
 	kubeclient, err := r.kubeconfigForCluster(ctx, util.ObjectKey(cluster))
 	if err != nil {
 		return err
@@ -32,7 +33,7 @@ func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, clust
 		}
 	}
 
-	c, err := r.talosconfigForMachines(ctx, machines...)
+	c, err := r.talosconfigForMachines(ctx, tcp, machines...)
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func (r *TalosControlPlaneReconciler) forceEtcdLeave(ctx context.Context, c *tal
 
 // auditEtcd rolls through all etcd members to see if there's a matching controlplane machine
 // It uses the first controlplane node returned as the etcd endpoint
-func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, cluster client.ObjectKey, cpName string) error {
+func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, tcp *controlplanev1.TalosControlPlane, cluster client.ObjectKey, cpName string) error {
 	machines, err := r.getControlPlaneMachinesForCluster(ctx, cluster, cpName)
 	if err != nil {
 		return err
@@ -182,7 +183,7 @@ func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, cluster cli
 		return fmt.Errorf("no CP machine which is not being deleted and has node ref")
 	}
 
-	c, err := r.talosconfigForMachines(ctx, designatedCPMachine)
+	c, err := r.talosconfigForMachines(ctx, tcp, designatedCPMachine)
 	if err != nil {
 		return err
 	}

--- a/controllers/health.go
+++ b/controllers/health.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	controlplanev1 "github.com/talos-systems/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	talosclient "github.com/talos-systems/talos/pkg/machinery/client"
 	"google.golang.org/grpc/codes"
@@ -27,8 +28,8 @@ func (e *errServiceUnhealthy) Error() string {
 	return fmt.Sprintf("Service %s is unhealthy: %s", e.service, e.reason)
 }
 
-func (r *TalosControlPlaneReconciler) nodesHealthcheck(ctx context.Context, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
-	client, err := r.talosconfigForMachines(ctx, machines...)
+func (r *TalosControlPlaneReconciler) nodesHealthcheck(ctx context.Context, tcp *controlplanev1.TalosControlPlane, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
+	client, err := r.talosconfigForMachines(ctx, tcp, machines...)
 	if err != nil {
 		return err
 	}
@@ -54,8 +55,8 @@ func (r *TalosControlPlaneReconciler) nodesHealthcheck(ctx context.Context, clus
 	return nil
 }
 
-func (r *TalosControlPlaneReconciler) ensureNodesBooted(ctx context.Context, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
-	client, err := r.talosconfigForMachines(ctx, machines...)
+func (r *TalosControlPlaneReconciler) ensureNodesBooted(ctx context.Context, tcp *controlplanev1.TalosControlPlane, cluster *clusterv1.Cluster, machines []clusterv1.Machine) error {
+	client, err := r.talosconfigForMachines(ctx, tcp, machines...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR contains couple of fixes. In case if tcp has `init` nodes
config:
- mark controlplane as bootstrapped immediately.
- populate nodes kubeconfig using workload cluster nodes info instead of
using machines addresses.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>