### PR TITLE
backports: for v0.4.5

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,7 +25,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
     fieldref:
       fieldpath: metadata.namespace
@@ -33,7 +33,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
   - name: SERVICE_NAMESPACE # namespace of the service
     objref:


### PR DESCRIPTION
See:
https://github.com/talos-systems/cluster-api-control-plane-provider-talos/pull/108
https://github.com/talos-systems/cluster-api-control-plane-provider-talos/pull/110